### PR TITLE
Used pytest SkipIf to skip the two tests causing the BucketNotFoundException for Issue#1

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,4 +1,5 @@
 import pytest
+import os
 from app import create_app
 from couchbase.cluster import Cluster
 from couchbase.auth import PasswordAuthenticator
@@ -32,13 +33,16 @@ def couchbase_setup(app):
     # Cleanup after tests
     collection.remove('test_doc')
 
-@pytest.mark.skipif(True, reason= "Skipping test for CI")
+def is_env_vars_not_configured():
+    return os.getenv('COUCHBASE_CONNECTION_STRING') is None or os.getenv('COUCHBASE_USERNAME') is None or os.getenv('COUCHBASE_PASSWORD') is None or os.getenv('COUCHBASE_DEFAULT_BUCKET') is None
+
+@pytest.mark.skipif(is_env_vars_not_configured(), reason = "Skipping as environment variables are not configured")
 def test_index(client):
     response = client.get("/")
     assert response.status_code == 200
     assert b"Welcome to Couchbase Flask Starter Kit" in response.data
 
-@pytest.mark.skipif(True, reason= "Skipping test for CI")
+@pytest.mark.skipif(is_env_vars_not_configured(), reason = "Skipping as environment variables are not configured")
 def test_create_and_get_document(client, couchbase_setup):
     # Create a document
     create_response = client.post("/documents", json={"id": "test_doc", "content": "Test content"})

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -32,11 +32,13 @@ def couchbase_setup(app):
     # Cleanup after tests
     collection.remove('test_doc')
 
+@pytest.mark.skipif(True, reason= "Skipping test for CI")
 def test_index(client):
     response = client.get("/")
     assert response.status_code == 200
     assert b"Welcome to Couchbase Flask Starter Kit" in response.data
 
+@pytest.mark.skipif(True, reason= "Skipping test for CI")
 def test_create_and_get_document(client, couchbase_setup):
     # Create a document
     create_response = client.post("/documents", json={"id": "test_doc", "content": "Test content"})


### PR DESCRIPTION
The issue here was caused by the testing being unable to locate a bucket at the given Couchbase connection string. This is configured by the user in the `.env` file, however the way this is setup now will cause testing to fail if the user does not have a valid bucket set up. While replicating this error we realized invalid `COUCHBASE_CONNECTION_STRING`, `COUCHBASE_USERNAME`, `COUCHBASE_PASSWORD`, or `COUCHBASE_DEFAULT_BUCKET` will all cause testing to fail. 
Replication of Issue:
![BucketNotFound](https://github.com/user-attachments/assets/662c132d-575e-4a9b-b2b0-32add6c3c342)

Our solution involved skipping the test if the user had not defined any of the aforementioned `.env` variables. We did this with a custom method which checks if they have all been defined by the user, and to only run testing once that has happened, skipping tests `test_index` and `test_create_and_get_document` if `.env` variables are not defined, this puts the exception as a responsibility of the user, and no longer a default of the template.
Default testing when the user has not defined `.env` values: 
![ExceptionSkip](https://github.com/user-attachments/assets/dbf654d7-6371-4a5e-b314-0de42e3e4c54)